### PR TITLE
Removing Eq and Show constraints

### DIFF
--- a/Data/Vec/Base.hs
+++ b/Data/Vec/Base.hs
@@ -27,11 +27,11 @@ import Foreign
 
 --for UArray instances
 import Data.Array.Base  as Array
-import GHC.ST		( ST(..), runST )
+import GHC.ST        ( ST(..), runST )
 import GHC.Prim
 import GHC.Base         ( Int(..) )
-import GHC.Float	( Float(..), Double(..) )
-import GHC.Word		( Word8(..) )
+import GHC.Float    ( Float(..), Double(..) )
+import GHC.Word        ( Word8(..) )
 
 
 -- | The vector constructor. @(:.)@ for vectors is like @(:)@ for lists, and
@@ -513,7 +513,7 @@ instance (Vec (Succ (Succ n)) a (a:.a:.v), Storable a, Storable (a:.v))
 --    If it's binary, it's a zipWith.
 
 instance
-    (Eq u, ShowVec u, Num a
+    (Num a
     ,Map a a (a:.u) (a:.u)
     ,ZipWith a a a (a:.u) (a:.u) (a:.u)
     ,Vec (Succ l) a (a:.u)
@@ -535,12 +535,11 @@ instance
 
 
 instance
-    (Eq u, ShowVec u, Fractional a
+    (Fractional a
     ,Ord (a:.u)
     ,ZipWith a a a (a:.u) (a:.u) (a:.u)
     ,Map a a (a:.u) (a:.u)
-    ,Vec (Succ l) a (a:.u)
-    ,Show (a:.u)
+    ,Vec (Succ l) a (a:.u)    
     )
     => Fractional (a:.u)
   where

--- a/Data/Vec/LinAlg.hs
+++ b/Data/Vec/LinAlg.hs
@@ -489,13 +489,10 @@ mapFst f (a,b) = (f a,b)
 {-# INLINE mapFst #-}
 
 
-class (Eq a, Num a) => NearZero a where
+class Num a => NearZero a where
   -- | @nearZero x@ should be true when x is close enough to 0 to cause
   -- significant error in division.
   nearZero :: a -> Bool
-  nearZero 0 = True
-  nearZero _ = False
-  {-# INLINE nearZero #-}
 
 instance NearZero Float where
   nearZero x = abs x < 1e-6
@@ -505,8 +502,11 @@ instance NearZero Double where
   nearZero x = abs x < 1e-14
   {-# INLINE nearZero #-}
 
-instance NearZero Rational
 
+instance NearZero Rational where
+  nearZero 0 = True
+  nearZero _ = False
+  {-# INLINE nearZero #-}
 
 
 
@@ -523,7 +523,7 @@ instance Pivot1 a () where
   pivot1 _ = Nothing
 
 instance
-    ( Show a, Fractional a, NearZero a
+    ( Fractional a, NearZero a
     ) => Pivot1 a ((a:.()):.())
   where
     pivot1 ((p:._):._)

--- a/Data/Vec/Packed.hs
+++ b/Data/Vec/Packed.hs
@@ -60,13 +60,13 @@ import Data.Int
 import Foreign
 
 import Data.Array.Base  as Array
-import GHC.ST		( ST(..), runST )
+import GHC.ST        ( ST(..), runST )
 import GHC.Prim
 import GHC.Base         ( Int(..) )
-import GHC.Word		( Word(..) )
-import GHC.Float	( Float(..), Double(..) )
-import GHC.Int		( Int8(..),  Int16(..),  Int32(..),  Int64(..) )
-import GHC.Word		( Word8(..), Word16(..), Word32(..), Word64(..) )
+import GHC.Word        ( Word(..) )
+import GHC.Float    ( Float(..), Double(..) )
+import GHC.Int        ( Int8(..),  Int16(..),  Int32(..),  Int64(..) )
+import GHC.Word        ( Word8(..), Word16(..), Word32(..), Word64(..) )
 
 
 -- | PackedVec class : relates a vector type to its space-optimized


### PR DESCRIPTION
These are the changes I suggest that makes Vec be more lean to use in DSLs.
The NearZero class doesnt have any default definitions any more, in order to remove the Eq constraint from it. The Rational instance was the only one relying on this default instance so I moved it there instead.
